### PR TITLE
Support localized title when rendering pertty links

### DIFF
--- a/src/DataType/CustomVocab.php
+++ b/src/DataType/CustomVocab.php
@@ -109,11 +109,11 @@ class CustomVocab extends AbstractDataType
             ->hydrate($valueObject, $value, $adapter);
     }
 
-    public function render(PhpRenderer $view, ValueRepresentation $value)
+    public function render(PhpRenderer $view, ValueRepresentation $value, $lang = null)
     {
         $valueResource = $value->valueResource();
         if ($valueResource) {
-            return $valueResource->linkPretty();
+            return $valueResource->linkPretty($lang);
         }
         return nl2br($view->escapeHtml($value->value()));
     }


### PR DESCRIPTION
In reference of core PR  https://github.com/omeka/omeka-s/pull/1692

In order to display localized titles when rendering a linked resource data type `asHtml()`, we need to pass on the corresponding language IETF tag as an optional value.