### PR TITLE
Store list of terms and uris as array

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -62,7 +62,7 @@ class Module extends AbstractModule
     public function install(ServiceLocatorInterface $serviceLocator)
     {
         $conn = $serviceLocator->get('Omeka\Connection');
-        $conn->exec('CREATE TABLE custom_vocab (id INT AUTO_INCREMENT NOT NULL, item_set_id INT DEFAULT NULL, owner_id INT DEFAULT NULL, `label` VARCHAR(190) NOT NULL, lang VARCHAR(190) DEFAULT NULL, terms LONGTEXT DEFAULT NULL, uris LONGTEXT DEFAULT NULL, UNIQUE INDEX UNIQ_8533D2A5EA750E8 (`label`), INDEX IDX_8533D2A5960278D7 (item_set_id), INDEX IDX_8533D2A57E3C61F9 (owner_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB;');
+        $conn->exec('CREATE TABLE custom_vocab (id INT AUTO_INCREMENT NOT NULL, item_set_id INT DEFAULT NULL, owner_id INT DEFAULT NULL, `label` VARCHAR(190) NOT NULL, lang VARCHAR(190) DEFAULT NULL, terms LONGTEXT DEFAULT NULL COMMENT "(DC2Type:json)", uris LONGTEXT DEFAULT NULL COMMENT "(DC2Type:json)", UNIQUE INDEX UNIQ_8533D2A5EA750E8 (`label`), INDEX IDX_8533D2A5960278D7 (item_set_id), INDEX IDX_8533D2A57E3C61F9 (owner_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB;');
         $conn->exec('ALTER TABLE custom_vocab ADD CONSTRAINT FK_8533D2A5960278D7 FOREIGN KEY (item_set_id) REFERENCES item_set (id) ON DELETE SET NULL;');
         $conn->exec('ALTER TABLE custom_vocab ADD CONSTRAINT FK_8533D2A57E3C61F9 FOREIGN KEY (owner_id) REFERENCES user (id) ON DELETE SET NULL;');
     }

--- a/data/doctrine-proxies/__CG__CustomVocabEntityCustomVocab.php
+++ b/data/doctrine-proxies/__CG__CustomVocabEntityCustomVocab.php
@@ -26,7 +26,7 @@ class CustomVocab extends \CustomVocab\Entity\CustomVocab implements \Doctrine\O
     /**
      * @var boolean flag indicating if this object was already initialized
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__isInitialized
+     * @see \Doctrine\Persistence\Proxy::__isInitialized
      */
     public $__isInitialized__ = false;
 

--- a/src/Api/Adapter/CustomVocabAdapter.php
+++ b/src/Api/Adapter/CustomVocabAdapter.php
@@ -64,9 +64,7 @@ class CustomVocabAdapter extends AbstractEntityAdapter
         }
         if ($this->shouldHydrate($request, 'o:terms')) {
             $terms = $this->sanitizeTerms($request->getValue('o:terms'));
-            if ('' === $terms) {
-                $terms = null;
-            }
+            $terms = $terms ? array_values($terms) : null;
             $entity->setTerms($terms);
         }
         if ($this->shouldHydrate($request, 'o:uris')) {
@@ -87,7 +85,10 @@ class CustomVocabAdapter extends AbstractEntityAdapter
             $errorStore->addError('o:label', 'The label is already taken.'); // @translate
         }
 
-        if ((null === $entity->getItemSet()) && (false == trim($entity->getTerms())) && (false == trim($entity->getUris()))) {
+        $itemSet = $entity->getItemSet();
+        $terms = $entity->getTerms();
+        $uris = $entity->getUris();
+        if ((null === $itemSet) && null === $terms && null === $uris) {
             $errorStore->addError('o:terms', 'The item set, terms, and URIs cannot all be empty.'); // @translate
         }
     }
@@ -95,18 +96,20 @@ class CustomVocabAdapter extends AbstractEntityAdapter
     protected function sanitizeTerms($terms)
     {
         // The str_replace() allows to fix Apple copy/paste.
-        $terms = explode("\n", str_replace(["\r\n", "\n\r", "\r"], ["\n", "\n", "\n"], $terms)); // explode at end of line
+        if (!is_array($terms)) {
+            $terms = explode("\n", str_replace(["\r\n", "\n\r", "\r"], ["\n", "\n", "\n"], $terms)); // explode at end of line
+        }
         $terms = array_map('trim', $terms); // trim all terms
         $terms = array_filter($terms); // remove empty terms
-        $terms = array_unique($terms); // remove duplicate terms
-        return trim(implode("\n", $terms));
+        return array_unique($terms); // remove duplicate terms
     }
 
     protected function sanitizeUris($uriLabels)
     {
         // The str_replace() allows to fix Apple copy/paste.
-        $uriLabels = explode("\n", str_replace(["\r\n", "\n\r", "\r"], ["\n", "\n", "\n"], $uriLabels)); // explode at end of line
-        $uriLabels = array_map('trim', $uriLabels); // trim all terms
-        return trim(implode("\n", $uriLabels));
+        if (!is_array($uriLabels)) {
+            $uriLabels = explode("\n", str_replace(["\r\n", "\n\r", "\r"], ["\n", "\n", "\n"], $uriLabels)); // explode at end of line
+        }
+        return array_map('trim', $uriLabels); // trim all terms
     }
 }

--- a/src/Api/Adapter/CustomVocabAdapter.php
+++ b/src/Api/Adapter/CustomVocabAdapter.php
@@ -14,6 +14,16 @@ class CustomVocabAdapter extends AbstractEntityAdapter
         'owner' => 'owner',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'label' => 'label',
+        'owner' => 'owner',
+        'lang' => 'lang',
+        'terms' => 'terms',
+        'uris' => 'uris',
+        'item_set' => 'itemSet',
+    ];
+
     public function getResourceName()
     {
         return 'custom_vocabs';

--- a/src/Api/Representation/CustomVocabRepresentation.php
+++ b/src/Api/Representation/CustomVocabRepresentation.php
@@ -133,11 +133,7 @@ class CustomVocabRepresentation extends AbstractEntityRepresentation
      */
     public function listTerms(): ?array
     {
-        $terms = trim($this->resource->getTerms());
-        if (!strlen($terms)) {
-            return null;
-        }
-        $terms = array_filter(array_map('trim', explode("\n", $terms)), 'strlen') ?: null;
+        $terms = $this->resource->getTerms();
         return $terms
             ? array_combine($terms, $terms)
             : null;
@@ -148,31 +144,22 @@ class CustomVocabRepresentation extends AbstractEntityRepresentation
      */
     public function listUriLabels(array $options = []): ?array
     {
-        $uris = trim($this->resource->getUris());
-        if (!strlen($uris)) {
+        $uris = $this->resource->getUris();
+        if (!$uris) {
             return null;
         }
         $result = [];
-        $matches = [];
         if (!empty($options['append_uri_to_label'])) {
             $sLabel = $this->getTranslator()->translate('%1$s <%2$s>'); // @translate
-            foreach (array_filter(array_map('trim', explode("\n", $uris)), 'strlen') as $uri) {
-                if (preg_match('/^(\S+) (.+)$/', $uri, $matches)) {
-                    $result[$matches[1]] = sprintf($sLabel, $matches[2], $matches[1]);
-                } elseif (preg_match('/^(.+)/', $uri, $matches)) {
-                    $result[$matches[1]] = $matches[1];
-                }
+            foreach ($uris as $uri => $label) {
+                $result[$uri] = strlen($label) ? sprintf($sLabel, $label, $uri) : $uri;
             }
         } else {
-            foreach (array_filter(array_map('trim', explode("\n", $uris)), 'strlen') as $uri) {
-                if (preg_match('/^(\S+) (.+)$/', $uri, $matches)) {
-                    $result[$matches[1]] = $matches[2];
-                } elseif (preg_match('/^(.+)/', $uri, $matches)) {
-                    $result[$matches[1]] = $matches[1];
-                }
+            foreach ($uris as $uri => $label) {
+                $result[$uri] = strlen($label) ? $label : $uri;
             }
         }
-        return $result ?: null;
+        return $result;
     }
 
     public function owner(): ?UserRepresentation

--- a/src/Entity/CustomVocab.php
+++ b/src/Entity/CustomVocab.php
@@ -34,12 +34,12 @@ class CustomVocab extends AbstractEntity
     protected $itemSet;
 
     /**
-     * @Column(nullable=true, type="text")
+     * @Column(nullable=true, type="json")
      */
     protected $terms;
 
     /**
-     * @Column(nullable=true, type="text")
+     * @Column(nullable=true, type="json")
      */
     protected $uris;
 

--- a/src/Form/CustomVocabForm.php
+++ b/src/Form/CustomVocabForm.php
@@ -2,6 +2,7 @@
 namespace CustomVocab\Form;
 
 use Laminas\Form\Form;
+use Omeka\Form\Element as OmekaElement;
 
 class CustomVocabForm extends Form
 {
@@ -63,10 +64,11 @@ class CustomVocabForm extends Form
 
         $this->add([
             'name' => 'o:terms',
-            'type' => 'textarea',
+            'type' => OmekaElement\ArrayTextarea::class,
             'options' => [
                 'label' => 'Terms', // @translate
                 'info' => 'Enter all the terms in this vocabulary, separated by new lines.', // @translate
+                'as_key_value' => false,
             ],
             'attributes' => [
                 'rows' => 20,
@@ -76,10 +78,12 @@ class CustomVocabForm extends Form
 
         $this->add([
             'name' => 'o:uris',
-            'type' => 'textarea',
+            'type' => OmekaElement\ArrayTextarea::class,
             'options' => [
                 'label' => 'URIs', // @translate
                 'info' => 'Enter all the URIs in this vocabulary, separated by new lines. You may label a URI by including the label after the URI, separated by a space.', // @translate
+                'as_key_value' => true,
+                'key_value_separator' => ' ',
             ],
             'attributes' => [
                 'rows' => 20,


### PR DESCRIPTION
Currently, the list of terms and uris are stored as a simple text that is exploded with preg each time. Furthermore, the api endpoint displays custom vocabs as text too, but this is not the right semantic. So to improve performance and to be more semantic, this pr aim is to store list as array to simplify process, for example or a js app. 

This feature does not change anything in the interface, but it may break some existing features in some advanced modules or themes that fetch custom vocabs, so it is the good time to normalize the output with omeka v4.

The json representation can be more semantic too, but it may be discussed or for a later request.