### PR TITLE
find items through search when dropdown not fully visible

### DIFF
--- a/asset/js/resource-form.js
+++ b/asset/js/resource-form.js
@@ -5,7 +5,7 @@ $(document).on('o:prepare-value', function(e, type, value) {
     }
     value.find('select').chosen({
         width: '100%',
-        disable_search_threshold: 25,
+        disable_search_threshold: 5,
         allow_single_deselect: true,
         // // More than 1000 may cause performance issues
         // @see https://github.com/harvesthq/chosen/issues/2580


### PR DESCRIPTION
If a "custom vocab" is the last component of a "resource template", and the list includes between 9 and 25 items, some of them are not visible. This is because the dropdown menu is at the very bottom of the screen, so even if it's scrollable, the last few items are not visible (tested on both Firefox and Chromium).

Setting the threshold for enabling search at 5 (or seemingly, at a value lower than 8, but 5 is probably safer), attenuates this issue, as at least users can search (it may still be mildly confusing that they don't see it when scrolling the dropdown, but at least there's an intuitive fix). Presently, there is simply no way to see the last few items in a list of e.g. 15 items and select them. As a workaround, one may click on "add value" a few times to gain some screen space for the dropdown menu, but this is obviously not a sensible approach.

Explanation with screenshots. 

When custom vocab is a last item in a resource template:
![Screenshot From 2025-01-15 23-44-06](https://github.com/user-attachments/assets/6a554505-f3ad-4440-aff6-7d0c22e9af39)

if there are, e.g., a dozen items, part of the screenshot is blanked out, even when scrolling down. (the white in the lower part is not an issue with the screenshot, it's how it's actually seen in the browser)
![Screenshot From 2025-01-15 23-43-57](https://github.com/user-attachments/assets/f0097853-fec8-4fdc-8068-80abd40da6a5)

A silly workaround is to add empty values to gain screen space, select what's needed, and then remove them:
![Screenshot From 2025-01-15 23-44-30](https://github.com/user-attachments/assets/4a9488de-58c5-4bec-9954-adcce3911a33)

Enabling search for smaller lists significantly attenuates this issue.
![Screenshot From 2025-01-15 23-53-55](https://github.com/user-attachments/assets/888afb03-fa48-4bdb-92af-56f25a38eb29)





